### PR TITLE
Gallery Mean Feature Vector

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@
 __pycache__
 fast-reid/datasets
 fast-reid/checkpoints
+Results/
+Videos/
+logs/

--- a/fast-reid/fastreid/config/defaults.py
+++ b/fast-reid/fastreid/config/defaults.py
@@ -300,6 +300,9 @@ _C.TEST = CN()
 
 _C.TEST.EVAL_PERIOD = 20
 
+# Use mean feature-vector for test images
+_C.TEST.MEAN_FEATURE_VECTOR = 'false'
+
 # Number of images per batch across all machines.
 _C.TEST.IMS_PER_BATCH = 64
 _C.TEST.METRIC = "cosine"

--- a/models/model_runner.py
+++ b/models/model_runner.py
@@ -23,6 +23,9 @@ def get_args():
                         help='If running track and crop on Data Processing, or if running track-and-reid model')
     parser.add_argument('--model_weights', help='The weights that should be used for inference (reID model)')
     parser.add_argument('--dataset', help='The name of the dataset that should be used in the reID model')
+    parser.add_argument('--gallery_mean_feature', action='store_true',
+                        help='If set, will compute the mean feature vector of every id in the test gallery')
+
     return parser.parse_args()
 
 
@@ -33,6 +36,8 @@ def create_optional_args() -> List:
     optional_args: List = []
     if args.model_weights:
         optional_args.extend(['MODEL.WEIGHTS', args.model_weights])
+    if args.gallery_mean_feature:
+        optional_args.extend(['TEST.MEAN_FEATURE_VECTOR', 'true'])
 
     return optional_args
 
@@ -90,7 +95,6 @@ def execute_combined_model():
     call(['/home/bar_cohen/miniconda3/envs/mmtrack/bin/python', './models/track_and_reid_model.py',
           args.track_config, args.reid_config, '--input', args.input, '--output', args.output, '--acc_th', args.acc_threshold,
           '--reid_opts', 'DATASETS.DATASET', args.dataset])
-
 
 
 def runner():

--- a/models/model_runner.py
+++ b/models/model_runner.py
@@ -1,4 +1,4 @@
-from argparse import ArgumentParser
+from argparse import ArgumentParser, REMAINDER
 from subprocess import call
 
 import sys
@@ -15,16 +15,12 @@ def get_args():
     parser.add_argument('--input', help='input video file or folder')
     parser.add_argument('--output', help='output video file (mp4 format) or folder')
     parser.add_argument('--mmtrack_checkpoint', help='checkpoint file for mmtrack model')
-    parser.add_argument('--reid_checkpoint', help='checkpoint file for reid model')
     parser.add_argument('--device', help='device to run on')
     parser.add_argument('--k_cluster', help='If running clustering on Data Processing')
     parser.add_argument('--capture_index', help='If running track and crop on Data Processing')
     parser.add_argument('--acc_threshold', default=0.8,
                         help='If running track and crop on Data Processing, or if running track-and-reid model')
-    parser.add_argument('--model_weights', help='The weights that should be used for inference (reID model)')
-    parser.add_argument('--dataset', help='The name of the dataset that should be used in the reID model')
-    parser.add_argument('--gallery_mean_feature', action='store_true',
-                        help='If set, will compute the mean feature vector of every id in the test gallery')
+    parser.add_argument('--reid_opts', help='Modify config options using the command-line', default=None, nargs=REMAINDER)
 
     return parser.parse_args()
 
@@ -34,11 +30,9 @@ def create_optional_args() -> List:
     Creates a list of optional arguments that if given should be appended to the sys.call arguments.
     """
     optional_args: List = []
-    if args.model_weights:
-        optional_args.extend(['MODEL.WEIGHTS', args.model_weights])
-    if args.gallery_mean_feature:
-        optional_args.extend(['TEST.MEAN_FEATURE_VECTOR', 'true'])
-
+    if args.reid_opts:
+        for opt in args.reid_opts:
+            optional_args.append(opt)
     return optional_args
 
 
@@ -66,7 +60,7 @@ def execute_reid_action():
     optional_args: List = create_optional_args()
     if args.action == RE_ID_TRAIN:
         script_args = ['/home/bar_cohen/miniconda3/envs/mmtrack/bin/python', './fast-reid/tools/train_net.py',
-                       '--config-file', args.reid_config, 'MODEL.DEVICE', 'cuda:0', 'DATASETS.DATASET', args.dataset]
+                       '--config-file', args.reid_config, 'MODEL.DEVICE', 'cuda:0']
         script_args.extend(optional_args)
         call(script_args)
 


### PR DESCRIPTION
- Added the option to generate a mean feature vector for all images of the same id in the test gallery. In this feature, instead of comparing each query image to all gallery images and then taking the id from the image with the lowest distance, we first compute the mean feature vector of every id in the test gallery. This way, we get in the test gallery only `num(ids)` feature vectors, which hopefully better represent each person.
- This feature can be used by adding the `--gallery_mean_feature` argument to the command arguments.