### PR TITLE
Support Device Selection

### DIFF
--- a/fast-reid/demo/predictor.py
+++ b/fast-reid/demo/predictor.py
@@ -121,6 +121,8 @@ class AsyncPredictor:
         self.result_queue = mp.Queue(maxsize=num_workers * 3)
         self.procs = []
         for gpuid in range(max(num_gpus, 1)):
+            if f'cuda:{gpuid}' != cfg.MODEL.DEVICE:
+                continue
             cfg = cfg.clone()
             cfg.defrost()
             cfg.MODEL.DEVICE = "cuda:{}".format(gpuid) if num_gpus > 0 else "cpu"

--- a/models/model_runner.py
+++ b/models/model_runner.py
@@ -34,7 +34,8 @@ def create_reid_opts() -> List:
     if args.reid_opts:
         for opt in args.reid_opts:
             reid_opts.append(opt)
-    reid_opts.extend(['MODEL.DEVICE', args.device])
+    if args.device:
+        reid_opts.extend(['MODEL.DEVICE', args.device])
     return reid_opts
 
 
@@ -105,6 +106,12 @@ def execute_combined_model():
     --output ./Results/Reid-Eval2-2.8-test.mp4 --acc_th 0.98 --crops_folder /mnt/raid1/home/bar_cohen/DB_Crops/
     --reid_opts DATASETS.DATASET inference_on_train_data MODEL.WEIGHTS ./fast-reid/checkpoints/scratch-id-by-day.pth
 
+    ByteTracker:
+    re-id-and-tracking --track_config ./mmtracking/configs/mot/bytetrack/bytetrack_yolox_x_crowdhuman_mot17-private -half.py
+    --mmtrack_checkpoint /home/bar_cohen/mmtracking/checkpoints/bytetrack_yolox_x_crowdhuman_mot17-private-half_20211218_205500-1985c9f0.pth
+    --reid_config ./fast-reid/configs/DukeMTMC/bagtricks_R101-ibn.yml --input /home/bar_cohen/KinderGuardian/Videos/trimmed_1.8.21-095724.mp4
+    --output ./Results/trimmed-bytetrack_labeled.mp4 --acc_th 0.7 --crops_folder /mnt/raid1/home/bar_cohen/DB_Test/
+    --device cuda:1 --reid_opts DATASETS.DATASET inference_on_train_data MODEL.WEIGHTS ./fast-reid/checkpoints/1.8.21-model.pth
     """
     reid_opts: List = create_reid_opts()
     optional_args: List = create_optional_args()

--- a/models/track_and_reid_model.py
+++ b/models/track_and_reid_model.py
@@ -236,7 +236,7 @@ def main():
     test_loader, num_query = build_reid_test_loader(reid_cfg, dataset_name='DukeMTMC')  # will take the dataset given as argument
 
     # build re-id inference model:
-    reid_model = FeatureExtractionDemo(reid_cfg, parallel=True)
+    reid_model = FeatureExtractionDemo(reid_cfg, parallel=False)
 
     # run re-id model on all images in the test gallery and query folders:
     feats, g_feat, g_pids, g_camids = apply_reid_model(reid_model, test_loader)
@@ -285,4 +285,4 @@ def main():
 
 if __name__ == '__main__':
     create_data_by_re_id_and_track()
-
+    # main()


### PR DESCRIPTION
- Support using the two GPUs in the server. This PR allows to set the device to "cuda:1", this way, the workload is split between the two GPUs.
- Update the args parsing of the reid model and the optional args for tracking.